### PR TITLE
Readd app.pack()

### DIFF
--- a/app/src/main/java/io/github/sj14/calculon/Calculon.java
+++ b/app/src/main/java/io/github/sj14/calculon/Calculon.java
@@ -368,6 +368,7 @@ public class Calculon extends javax.swing.JFrame {
 
                 app.resultsTextPane.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
                 app.statusBar.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+                app.pack();
                 app.setLocationRelativeTo(null);
                 app.restoreWindowSize();
                 app.setVisible(true);


### PR DESCRIPTION
It was removed in #12 but I think it was needed for centring the window (now only used on the first start ever, as we store the window position now).